### PR TITLE
Define config types and parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/auth-mux

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: build
+build: auth-mux
+
+auth-mux:
+	go build -o $@ ./cmd/$@
+
+.PHONY: clean
+clean:
+	rm -f auth-mux

--- a/cmd/auth-mux/main.go
+++ b/cmd/auth-mux/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"log"
+
+	"github.com/robbiemcmichael/auth-mux/internal/config"
+)
+
+func main() {
+	data, err := ioutil.ReadFile("config.yaml")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var config config.Config
+
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", config)
+	fmt.Printf("%+v\n", config.Inputs[0].Config)
+	fmt.Printf("%+v\n", config.Outputs[0].Config)
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,21 @@
+cert: tls.crt
+key: tls.key
+inputs:
+- type: KubernetesTokenReview
+  name: kubernetes
+  path: /kubernetes
+  config:
+    publicKey: key.pub
+    audience: kubernetes
+    claims:
+      uid: sub
+      user: sub
+      groups: groups
+    prefix: spiffe://domain/path
+outputs:
+- type: KubernetesTokenReview
+  name: kubernetes
+  path: /kubernetes
+  config:
+    audience: kubernetes
+    maxTTL: 300

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/robbiemcmichael/auth-mux
+
+go 1.12
+
+require gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+
+	"github.com/robbiemcmichael/auth-mux/internal/input"
+	"github.com/robbiemcmichael/auth-mux/internal/output"
+)
+
+type Config struct {
+	Cert    string   `yaml:"cert"`
+	Key     string   `yaml:"key"`
+	Inputs  []Input  `yaml:"inputs"`
+	Outputs []Output `yaml:"outputs"`
+}
+
+// An Input is able to validate an HTTP request and return a set of
+// authentication claims
+type Input struct {
+	Type   string
+	Name   string
+	Path   string
+	Config input.Input
+}
+
+func (i *Input) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var wrapper struct {
+		Type   string `yaml:"type"`
+		Name   string `yaml:"name"`
+		Path   string `yaml:"path"`
+		Config interface{} `yaml:"config"`
+	}
+
+	if err := unmarshal(&wrapper); err != nil {
+		return fmt.Errorf("unmarshal Input: %v", err)
+	}
+
+	var config input.Input
+
+	switch t := wrapper.Type; t {
+	case "KubernetesTokenReview":
+		config = new(input.KubernetesTokenReview)
+	default:
+		return fmt.Errorf("unmarshal Input: unknown type %q", t)
+	}
+
+	b, err := yaml.Marshal(wrapper.Config)
+	if err != nil {
+		return fmt.Errorf("re-marshal config: %v", err)
+	}
+
+	// Unmarshal the input config based on the input type
+	if err := yaml.Unmarshal(b, config); err != nil {
+		return fmt.Errorf("unmarshal Input config: %v", err)
+	}
+
+	*i = Input{
+		Type: wrapper.Type,
+		Name: wrapper.Name,
+		Path: wrapper.Path,
+		Config: config,
+	}
+
+	return nil
+}
+
+// An Ouput takes a set of authentication claims and provides the HTTP response
+type Output struct {
+	Type   string
+	Name   string
+	Path   string
+	Config output.Output
+}
+
+func (o *Output) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var wrapper struct {
+		Type   string `yaml:"type"`
+		Name   string `yaml:"name"`
+		Path   string `yaml:"path"`
+		Config interface{} `yaml:"config"`
+	}
+
+	if err := unmarshal(&wrapper); err != nil {
+		return fmt.Errorf("unmarshal Output: %v", err)
+	}
+
+	var config output.Output
+
+	switch t := wrapper.Type; t {
+	case "KubernetesTokenReview":
+		config = new(output.KubernetesTokenReview)
+	default:
+		return fmt.Errorf("unmarshal Output: unknown type %q", t)
+	}
+
+	b, err := yaml.Marshal(wrapper.Config)
+	if err != nil {
+		return fmt.Errorf("re-marshal config: %v", err)
+	}
+
+	// Unmarshal the output config based on the output type
+	if err := yaml.Unmarshal(b, config); err != nil {
+		return fmt.Errorf("unmarshal Output config: %v", err)
+	}
+
+	*o = Output{
+		Type: wrapper.Type,
+		Name: wrapper.Name,
+		Path: wrapper.Path,
+		Config: config,
+	}
+
+	return nil
+}

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -1,0 +1,5 @@
+package input
+
+type Input interface {
+	Config() string
+}

--- a/internal/input/kubernetesTokenReview.go
+++ b/internal/input/kubernetesTokenReview.go
@@ -1,0 +1,23 @@
+package input
+
+import (
+	"fmt"
+)
+
+type KubernetesTokenReview struct {
+	PublicKey    string    `yaml:"publicKey"`
+	Audience     string    `yaml:"audience"`
+	Claims       JWTClaims `yaml:"claims"`
+	Prefix       string    `yaml:"prefix"`
+}
+
+type JWTClaims struct {
+	UIDClaim    string `yaml:"uid"`
+	UserClaim   string `yaml:"user"`
+	GroupsClaim string `yaml:"groups"`
+	ExtraClaim  string `yaml:"extra"`
+}
+
+func (i *KubernetesTokenReview) Config() string {
+	return fmt.Sprintf("%+v", i)
+}

--- a/internal/output/kubernetesTokenReview.go
+++ b/internal/output/kubernetesTokenReview.go
@@ -1,0 +1,14 @@
+package output
+
+import (
+	"fmt"
+)
+
+type KubernetesTokenReview struct {
+	Audience string `yaml:"audience"`
+	MaxTTL   int64  `yaml:"maxTTL"`
+}
+
+func (o *KubernetesTokenReview) Config() string {
+	return fmt.Sprintf("%+v", o)
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,5 @@
+package output
+
+type Output interface {
+	Config() string
+}


### PR DESCRIPTION
- Initialises the project
- Defines overall config structure
- Defines interfaces for authentication inputs/outputs
- Conditionally parses input/output config based on its type
- Adds `KubernetesTokenReview` as both an input and an output