### PR TITLE
Add Identity output

### DIFF
--- a/cmd/auth-mux/main.go
+++ b/cmd/auth-mux/main.go
@@ -22,7 +22,11 @@ func handler(i internal.Input, o internal.Output) http.HandlerFunc {
 			return
 		}
 
-		log.Printf("Authentication successful: %+v", validation)
+		if validation.Valid {
+			log.Printf("Valid authentication: %+v\n", validation)
+		} else {
+			log.Printf("Invalid authentication: %+v\n", validation)
+		}
 
 		if err := o.Config.Handler(w, validation); err != nil {
 			log.Printf("output handler for %q: %v", o.Name, err)

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,9 @@ inputs:
       subject: sub
       groups: groups
 outputs:
+- type: Identity
+  name: identity
+  path: /
 - type: KubernetesTokenReview
   name: kubernetes
   path: /kubernetes

--- a/internal/config.go
+++ b/internal/config.go
@@ -90,6 +90,8 @@ func (o *Output) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var config output.Output
 
 	switch t := wrapper.Type; t {
+	case "Identity":
+		config = new(output.Identity)
 	case "KubernetesTokenReview":
 		config = new(output.KubernetesTokenReview)
 	default:

--- a/internal/output/identity.go
+++ b/internal/output/identity.go
@@ -1,0 +1,14 @@
+package output
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/robbiemcmichael/auth-mux/internal/types"
+)
+
+type Identity struct{}
+
+func (o *Identity) Handler(w http.ResponseWriter, validation types.Validation) error {
+	return json.NewEncoder(w).Encode(validation)
+}


### PR DESCRIPTION
Adds the `Identity` output, which is just the identity function applied to the `Validation` type, serialising it as JSON and returning it in the HTTP response. This is quite useful for debugging so it has been given an output path of `/` in the example config file, effectively making it the default output type.