### PR TITLE
Modular token validation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,18 +5,21 @@ inputs:
   name: kubernetes
   path: /kubernetes
   config:
-    audience:
-    - kubernetes
-    issuers:
-      domain:
-        publicKey: key.pub
-        idPrefix: spiffe://domain/path
-        subjectPrefix: spiffe://domain/path
-        groupPrefix: spiffe://domain/path
-    claims:
-      id: sub
-      subject: sub
-      groups: groups
+    validator:
+      type: JWT
+      config:
+        audience:
+        - kubernetes
+        issuers:
+          domain:
+            publicKey: key.pub
+            idPrefix: spiffe://domain/path
+            subjectPrefix: spiffe://domain/path
+            groupPrefix: spiffe://domain/path
+        claims:
+          id: sub
+          subject: sub
+          groups: groups
 outputs:
 - type: Identity
   name: identity

--- a/internal/config.go
+++ b/internal/config.go
@@ -45,7 +45,7 @@ func (i *Input) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	switch t := wrapper.Type; t {
 	case "KubernetesTokenReview":
-		config = new(inputKubernetesTokenReview.Input)
+		config = new(inputKubernetesTokenReview.Config)
 	default:
 		return fmt.Errorf("unmarshal Input: unknown type %q", t)
 	}
@@ -57,7 +57,7 @@ func (i *Input) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	// Unmarshal the input config based on the input type
 	if err := yaml.Unmarshal(b, config); err != nil {
-		return fmt.Errorf("unmarshal Input config: %v", err)
+		return fmt.Errorf("unmarshal %s config: %v", wrapper.Type, err)
 	}
 
 	*i = Input{
@@ -94,9 +94,9 @@ func (o *Output) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	switch t := wrapper.Type; t {
 	case "Identity":
-		config = new(outputIdentity.Output)
+		config = new(outputIdentity.Config)
 	case "KubernetesTokenReview":
-		config = new(outputKubernetesTokenReview.Output)
+		config = new(outputKubernetesTokenReview.Config)
 	default:
 		return fmt.Errorf("unmarshal Output: unknown type %q", t)
 	}
@@ -108,7 +108,7 @@ func (o *Output) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	// Unmarshal the output config based on the output type
 	if err := yaml.Unmarshal(b, config); err != nil {
-		return fmt.Errorf("unmarshal Output config: %v", err)
+		return fmt.Errorf("unmarshal %s config: %v", wrapper.Type, err)
 	}
 
 	*o = Output{

--- a/internal/config.go
+++ b/internal/config.go
@@ -6,7 +6,10 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/robbiemcmichael/auth-mux/internal/input"
+	inputKubernetesTokenReview "github.com/robbiemcmichael/auth-mux/internal/input/kubernetesTokenReview"
 	"github.com/robbiemcmichael/auth-mux/internal/output"
+	outputIdentity "github.com/robbiemcmichael/auth-mux/internal/output/identity"
+	outputKubernetesTokenReview "github.com/robbiemcmichael/auth-mux/internal/output/kubernetesTokenReview"
 )
 
 type Config struct {
@@ -42,7 +45,7 @@ func (i *Input) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	switch t := wrapper.Type; t {
 	case "KubernetesTokenReview":
-		config = new(input.KubernetesTokenReview)
+		config = new(inputKubernetesTokenReview.Input)
 	default:
 		return fmt.Errorf("unmarshal Input: unknown type %q", t)
 	}
@@ -91,9 +94,9 @@ func (o *Output) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	switch t := wrapper.Type; t {
 	case "Identity":
-		config = new(output.Identity)
+		config = new(outputIdentity.Output)
 	case "KubernetesTokenReview":
-		config = new(output.KubernetesTokenReview)
+		config = new(outputKubernetesTokenReview.Output)
 	default:
 		return fmt.Errorf("unmarshal Output: unknown type %q", t)
 	}

--- a/internal/input/kubernetesTokenReview/input.go
+++ b/internal/input/kubernetesTokenReview/input.go
@@ -1,4 +1,4 @@
-package input
+package kubernetesTokenReview
 
 import (
 	"crypto/x509"
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-type KubernetesTokenReview struct {
+type Input struct {
 	// Token will be rejected if the audience does not match
 	Audience []string `yaml:"audience"`
 	// A map containing issuers and their validation configuration
@@ -48,7 +48,7 @@ type JWTClaims struct {
 	Extra string `yaml:"extra"`
 }
 
-func (i *KubernetesTokenReview) Handler(r *http.Request) (types.Validation, error) {
+func (i *Input) Handler(r *http.Request) (types.Validation, error) {
 	decoder := json.NewDecoder(r.Body)
 
 	var tokenReview auth.TokenReview
@@ -64,7 +64,7 @@ func (i *KubernetesTokenReview) Handler(r *http.Request) (types.Validation, erro
 	return validation, nil
 }
 
-func (i *KubernetesTokenReview) validateToken(tokenString string) (types.Validation, error) {
+func (i *Input) validateToken(tokenString string) (types.Validation, error) {
 	token, err := jwt.ParseSigned(tokenString)
 	if err != nil {
 		invalid := types.Validation{

--- a/internal/input/kubernetesTokenReview/input.go
+++ b/internal/input/kubernetesTokenReview/input.go
@@ -1,54 +1,21 @@
 package kubernetesTokenReview
 
 import (
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"time"
 
 	auth "k8s.io/api/authentication/v1"
 
+	"github.com/robbiemcmichael/auth-mux/internal/token"
 	"github.com/robbiemcmichael/auth-mux/internal/types"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-type Input struct {
-	// Token will be rejected if the audience does not match
-	Audience []string `yaml:"audience"`
-	// A map containing issuers and their validation configuration
-	Issuers map[string]*Issuer `yaml:"issuers"`
-	// Fields used to extract claims from the JWT
-	Claims JWTClaims `yaml:"claims"`
+type Config struct {
+	Validator token.Config `yaml:"validator"`
 }
 
-type Issuer struct {
-	// Path to the public key used to verify the JWT
-	PublicKeyFile string `yaml:"publicKey"`
-	// Parsed public key (*rsa.PublicKey, *dsa.PublicKey or *ecdsa.PublicKey)
-	PublicKey interface{}
-	// Assert that the ID includes a prefix
-	IDPrefix string `yaml:"idPrefix"`
-	// Assert that the subject includes a prefix
-	SubjectPrefix string `yaml:"subjectPrefix"`
-	// Assert that the groups include a prefix
-	GroupPrefix string `yaml:"groupPrefix"`
-}
-
-type JWTClaims struct {
-	// JWT claim to map to the ID
-	ID string `yaml:"id"`
-	// JWT claim to map to the subject
-	Subject string `yaml:"subject"`
-	// JWT claim to map to the groups
-	Groups string `yaml:"groups"`
-	// JWT claim to map to extra
-	Extra string `yaml:"extra"`
-}
-
-func (i *Input) Handler(r *http.Request) (types.Validation, error) {
+func (c *Config) Handler(r *http.Request) (types.Validation, error) {
 	decoder := json.NewDecoder(r.Body)
 
 	var tokenReview auth.TokenReview
@@ -56,166 +23,10 @@ func (i *Input) Handler(r *http.Request) (types.Validation, error) {
 		return types.Validation{}, fmt.Errorf("decode JSON: %v", err)
 	}
 
-	validation, err := i.validateToken(tokenReview.Spec.Token)
+	validation, err := c.Validator.Config.Validate(tokenReview.Spec.Token)
 	if err != nil {
 		return types.Validation{}, fmt.Errorf("validate token: %v", err)
 	}
 
 	return validation, nil
-}
-
-func (i *Input) validateToken(tokenString string) (types.Validation, error) {
-	token, err := jwt.ParseSigned(tokenString)
-	if err != nil {
-		invalid := types.Validation{
-			Valid: false,
-			Error: fmt.Sprintf("Failed to parse token: %v\n", err),
-		}
-		return invalid, nil
-	}
-
-	issuerString, err := getIssuer(*token)
-	if err != nil {
-		invalid := types.Validation{
-			Valid: false,
-			Error: fmt.Sprintf("Failed to extract token claims: %v\n", err),
-		}
-		return invalid, nil
-	}
-
-	issuer := i.Issuers[issuerString]
-	if issuer == nil {
-		invalid := types.Validation{
-			Valid: false,
-			Error: fmt.Sprintf("Invalid token: unknown issuer %q\n", issuerString),
-		}
-		return invalid, nil
-	}
-
-	if issuer.PublicKey == nil {
-		if err := issuer.parsePublicKey(); err != nil {
-			return types.Validation{}, fmt.Errorf("parse public key for issuer %q: %v", issuerString, err)
-		}
-	}
-
-	var publicClaims jwt.Claims
-	if err := token.Claims(issuer.PublicKey, &publicClaims); err != nil {
-		invalid := types.Validation{
-			Valid: false,
-			Error: fmt.Sprintf("Failed to extract token claims: %v\n", err),
-		}
-		return invalid, nil
-	}
-
-	expected := jwt.Expected{
-		Audience: i.Audience,
-		Time:     time.Now(),
-	}
-
-	if err := publicClaims.Validate(expected); err != nil {
-		invalid := types.Validation{
-			Valid: false,
-			Error: fmt.Sprintf("Invalid token: %v\n", err),
-		}
-		return invalid, nil
-	}
-
-	identity, err := getIdentity(*token, i.Claims)
-	if err != nil {
-		invalid := types.Validation{
-			Valid: false,
-			Error: fmt.Sprintf("Invalid token: %v\n", err),
-		}
-		return invalid, nil
-	}
-
-	validation := types.Validation{
-		Valid:  true,
-		Claims: identity,
-	}
-
-	assertion := types.Assertion{
-		IDPrefix:      issuer.IDPrefix,
-		SubjectPrefix: issuer.SubjectPrefix,
-		GroupPrefix:   issuer.GroupPrefix,
-	}
-
-	validation.Assert(assertion)
-
-	return validation, nil
-}
-
-func (issuer *Issuer) parsePublicKey() error {
-	contents, err := ioutil.ReadFile(issuer.PublicKeyFile)
-	if err != nil {
-		return err
-	}
-
-	block, _ := pem.Decode(contents)
-	if block == nil {
-		return fmt.Errorf("failed to read PEM block")
-	}
-
-	key, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return err
-	}
-
-	issuer.PublicKey = key
-	return nil
-}
-
-func getIssuer(token jwt.JSONWebToken) (string, error) {
-	var publicClaims jwt.Claims
-	if err := token.UnsafeClaimsWithoutVerification(&publicClaims); err != nil {
-		return "", err
-	}
-
-	return publicClaims.Issuer, nil
-}
-
-func getIdentity(token jwt.JSONWebToken, fields JWTClaims) (types.Claims, error) {
-	var claims interface{}
-	if err := token.UnsafeClaimsWithoutVerification(&claims); err != nil {
-		return types.Claims{}, err
-	}
-
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return types.Claims{}, fmt.Errorf("failed to cast JWT claims to map[string]interface{}")
-	}
-
-	id, ok := claimsMap[fields.ID].(string)
-	if !ok {
-		return types.Claims{}, fmt.Errorf("failed to cast %q claim to string", fields.ID)
-	}
-
-	subject, ok := claimsMap[fields.Subject].(string)
-	if !ok {
-		return types.Claims{}, fmt.Errorf("failed to cast %q claim to string", fields.Subject)
-	}
-
-	interfaceArray, ok := claimsMap[fields.Groups].([]interface{})
-	if !ok {
-		return types.Claims{}, fmt.Errorf("failed to cast %q claim to []interface{}", fields.Groups)
-	}
-
-	groups := make([]string, len(interfaceArray))
-	for i, v := range interfaceArray {
-		group, ok := v.(string)
-		if !ok {
-			return types.Claims{}, fmt.Errorf("failed to cast group to string: %v", v)
-		}
-
-		groups[i] = group
-	}
-
-	c := types.Claims{
-		ID:      id,
-		Subject: subject,
-		Groups:  groups,
-		Extra:   claimsMap[fields.Extra],
-	}
-
-	return c, nil
 }

--- a/internal/output/identity/output.go
+++ b/internal/output/identity/output.go
@@ -7,8 +7,8 @@ import (
 	"github.com/robbiemcmichael/auth-mux/internal/types"
 )
 
-type Output struct{}
+type Config struct{}
 
-func (o *Output) Handler(w http.ResponseWriter, validation types.Validation) error {
+func (c *Config) Handler(w http.ResponseWriter, validation types.Validation) error {
 	return json.NewEncoder(w).Encode(validation)
 }

--- a/internal/output/identity/output.go
+++ b/internal/output/identity/output.go
@@ -1,4 +1,4 @@
-package output
+package identity
 
 import (
 	"encoding/json"
@@ -7,8 +7,8 @@ import (
 	"github.com/robbiemcmichael/auth-mux/internal/types"
 )
 
-type Identity struct{}
+type Output struct{}
 
-func (o *Identity) Handler(w http.ResponseWriter, validation types.Validation) error {
+func (o *Output) Handler(w http.ResponseWriter, validation types.Validation) error {
 	return json.NewEncoder(w).Encode(validation)
 }

--- a/internal/output/kubernetesTokenReview/output.go
+++ b/internal/output/kubernetesTokenReview/output.go
@@ -10,12 +10,12 @@ import (
 	"github.com/robbiemcmichael/auth-mux/internal/types"
 )
 
-type Output struct {
+type Config struct {
 	Audience string `yaml:"audience"`
 	MaxTTL   int64  `yaml:"maxTTL"`
 }
 
-func (o *Output) Handler(w http.ResponseWriter, validation types.Validation) error {
+func (c *Config) Handler(w http.ResponseWriter, validation types.Validation) error {
 	tokenReview := auth.TokenReview{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: auth.SchemeGroupVersion.String(),

--- a/internal/output/kubernetesTokenReview/output.go
+++ b/internal/output/kubernetesTokenReview/output.go
@@ -1,4 +1,4 @@
-package output
+package kubernetesTokenReview
 
 import (
 	"encoding/json"
@@ -10,12 +10,12 @@ import (
 	"github.com/robbiemcmichael/auth-mux/internal/types"
 )
 
-type KubernetesTokenReview struct {
+type Output struct {
 	Audience string `yaml:"audience"`
 	MaxTTL   int64  `yaml:"maxTTL"`
 }
 
-func (o *KubernetesTokenReview) Handler(w http.ResponseWriter, validation types.Validation) error {
+func (o *Output) Handler(w http.ResponseWriter, validation types.Validation) error {
 	tokenReview := auth.TokenReview{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: auth.SchemeGroupVersion.String(),

--- a/internal/token/jwt/jwt.go
+++ b/internal/token/jwt/jwt.go
@@ -1,0 +1,202 @@
+package jwt
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	joseJWT "gopkg.in/square/go-jose.v2/jwt"
+
+	"github.com/robbiemcmichael/auth-mux/internal/types"
+)
+
+type Config struct {
+	// Token will be rejected if the audience does not match
+	Audience []string `yaml:"audience"`
+	// A map containing issuers and their validation configuration
+	Issuers map[string]*Issuer `yaml:"issuers"`
+	// Fields used to extract claims from the JWT
+	Claims JWTClaims `yaml:"claims"`
+}
+
+type Issuer struct {
+	// Path to the public key used to verify the JWT
+	PublicKeyFile string `yaml:"publicKey"`
+	// Parsed public key (*rsa.PublicKey, *dsa.PublicKey or *ecdsa.PublicKey)
+	PublicKey interface{}
+	// Assert that the ID includes a prefix
+	IDPrefix string `yaml:"idPrefix"`
+	// Assert that the subject includes a prefix
+	SubjectPrefix string `yaml:"subjectPrefix"`
+	// Assert that the groups include a prefix
+	GroupPrefix string `yaml:"groupPrefix"`
+}
+
+type JWTClaims struct {
+	// JWT claim to map to the ID
+	ID string `yaml:"id"`
+	// JWT claim to map to the subject
+	Subject string `yaml:"subject"`
+	// JWT claim to map to the groups
+	Groups string `yaml:"groups"`
+	// JWT claim to map to extra
+	Extra string `yaml:"extra"`
+}
+
+func (c *Config) Validate(tokenString string) (types.Validation, error) {
+	token, err := joseJWT.ParseSigned(tokenString)
+	if err != nil {
+		invalid := types.Validation{
+			Valid: false,
+			Error: fmt.Sprintf("Failed to parse token: %v\n", err),
+		}
+		return invalid, nil
+	}
+
+	issuerString, err := getIssuer(*token)
+	if err != nil {
+		invalid := types.Validation{
+			Valid: false,
+			Error: fmt.Sprintf("Failed to extract token claims: %v\n", err),
+		}
+		return invalid, nil
+	}
+
+	issuer := c.Issuers[issuerString]
+	if issuer == nil {
+		invalid := types.Validation{
+			Valid: false,
+			Error: fmt.Sprintf("Invalid token: unknown issuer %q\n", issuerString),
+		}
+		return invalid, nil
+	}
+
+	if issuer.PublicKey == nil {
+		if err := issuer.parsePublicKey(); err != nil {
+			return types.Validation{}, fmt.Errorf("parse public key for issuer %q: %v", issuerString, err)
+		}
+	}
+
+	var publicClaims joseJWT.Claims
+	if err := token.Claims(issuer.PublicKey, &publicClaims); err != nil {
+		invalid := types.Validation{
+			Valid: false,
+			Error: fmt.Sprintf("Failed to extract token claims: %v\n", err),
+		}
+		return invalid, nil
+	}
+
+	expected := joseJWT.Expected{
+		Audience: c.Audience,
+		Time:     time.Now(),
+	}
+
+	if err := publicClaims.Validate(expected); err != nil {
+		invalid := types.Validation{
+			Valid: false,
+			Error: fmt.Sprintf("Invalid token: %v\n", err),
+		}
+		return invalid, nil
+	}
+
+	identity, err := getIdentity(*token, c.Claims)
+	if err != nil {
+		invalid := types.Validation{
+			Valid: false,
+			Error: fmt.Sprintf("Invalid token: %v\n", err),
+		}
+		return invalid, nil
+	}
+
+	validation := types.Validation{
+		Valid:  true,
+		Claims: identity,
+	}
+
+	assertion := types.Assertion{
+		IDPrefix:      issuer.IDPrefix,
+		SubjectPrefix: issuer.SubjectPrefix,
+		GroupPrefix:   issuer.GroupPrefix,
+	}
+
+	validation.Assert(assertion)
+
+	return validation, nil
+}
+
+func (issuer *Issuer) parsePublicKey() error {
+	contents, err := ioutil.ReadFile(issuer.PublicKeyFile)
+	if err != nil {
+		return err
+	}
+
+	block, _ := pem.Decode(contents)
+	if block == nil {
+		return fmt.Errorf("failed to read PEM block")
+	}
+
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return err
+	}
+
+	issuer.PublicKey = key
+	return nil
+}
+
+func getIssuer(token joseJWT.JSONWebToken) (string, error) {
+	var publicClaims joseJWT.Claims
+	if err := token.UnsafeClaimsWithoutVerification(&publicClaims); err != nil {
+		return "", err
+	}
+
+	return publicClaims.Issuer, nil
+}
+
+func getIdentity(token joseJWT.JSONWebToken, fields JWTClaims) (types.Claims, error) {
+	var claims interface{}
+	if err := token.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		return types.Claims{}, err
+	}
+
+	claimsMap, ok := claims.(map[string]interface{})
+	if !ok {
+		return types.Claims{}, fmt.Errorf("failed to cast JWT claims to map[string]interface{}")
+	}
+
+	id, ok := claimsMap[fields.ID].(string)
+	if !ok {
+		return types.Claims{}, fmt.Errorf("failed to cast %q claim to string", fields.ID)
+	}
+
+	subject, ok := claimsMap[fields.Subject].(string)
+	if !ok {
+		return types.Claims{}, fmt.Errorf("failed to cast %q claim to string", fields.Subject)
+	}
+
+	interfaceArray, ok := claimsMap[fields.Groups].([]interface{})
+	if !ok {
+		return types.Claims{}, fmt.Errorf("failed to cast %q claim to []interface{}", fields.Groups)
+	}
+
+	groups := make([]string, len(interfaceArray))
+	for i, v := range interfaceArray {
+		group, ok := v.(string)
+		if !ok {
+			return types.Claims{}, fmt.Errorf("failed to cast group to string: %v", v)
+		}
+
+		groups[i] = group
+	}
+
+	c := types.Claims{
+		ID:      id,
+		Subject: subject,
+		Groups:  groups,
+		Extra:   claimsMap[fields.Extra],
+	}
+
+	return c, nil
+}

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,56 @@
+package token
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/robbiemcmichael/auth-mux/internal/token/jwt"
+	"github.com/robbiemcmichael/auth-mux/internal/types"
+)
+
+type Validator interface {
+	Validate(string) (types.Validation, error)
+}
+
+type Config struct {
+	Type   string
+	Config Validator
+}
+
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var wrapper struct {
+		Type   string      `yaml:"type"`
+		Config interface{} `yaml:"config"`
+	}
+
+	if err := unmarshal(&wrapper); err != nil {
+		return fmt.Errorf("unmarshal Token: %v", err)
+	}
+
+	var config Validator
+
+	switch t := wrapper.Type; t {
+	case "JWT":
+		config = new(jwt.Config)
+	default:
+		return fmt.Errorf("unmarshal Token: unknown type %q", t)
+	}
+
+	b, err := yaml.Marshal(wrapper.Config)
+	if err != nil {
+		return fmt.Errorf("re-marshal config: %v", err)
+	}
+
+	// Unmarshal the token config based on the token type
+	if err := yaml.Unmarshal(b, config); err != nil {
+		return fmt.Errorf("unmarshal %s config: %v", wrapper.Type, err)
+	}
+
+	*c = Config{
+		Type:   wrapper.Type,
+		Config: config,
+	}
+
+	return nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -6,16 +6,16 @@ import (
 )
 
 type Validation struct {
-	Valid  bool
-	Error  string
-	Claims Claims
+	Valid  bool   `yaml:"valid"`
+	Error  string `yaml:"error"`
+	Claims Claims `yaml:"claims"`
 }
 
 type Claims struct {
-	ID      string
-	Subject string
-	Groups  []string
-	Extra   interface{}
+	ID      string      `yaml:"id"`
+	Subject string      `yaml:"subject"`
+	Groups  []string    `yaml:"groups"`
+	Extra   interface{} `yaml:"extra"`
 }
 
 type Assertion struct {


### PR DESCRIPTION
- Isolates inputs/outputs as separate packages to avoid naming collisions
- Makes token validation modular so that the validation logic can be reused across many inputs