### PR TITLE
Add support for bearer authentication

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,25 @@
 cert: tls.crt
 key: tls.key
 inputs:
+- type: Bearer
+  name: bearer
+  path: /bearer
+  config:
+    validator:
+      type: JWT
+      config:
+        audience:
+        - kubernetes
+        issuers:
+          domain:
+            publicKey: key.pub
+            idPrefix: spiffe://domain/path
+            subjectPrefix: spiffe://domain/path
+            groupPrefix: spiffe://domain/path
+        claims:
+          id: sub
+          subject: sub
+          groups: groups
 - type: KubernetesTokenReview
   name: kubernetes
   path: /kubernetes

--- a/internal/config.go
+++ b/internal/config.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/robbiemcmichael/auth-mux/internal/input"
+	inputBearer "github.com/robbiemcmichael/auth-mux/internal/input/bearer"
 	inputKubernetesTokenReview "github.com/robbiemcmichael/auth-mux/internal/input/kubernetesTokenReview"
 	"github.com/robbiemcmichael/auth-mux/internal/output"
 	outputIdentity "github.com/robbiemcmichael/auth-mux/internal/output/identity"
@@ -44,6 +45,8 @@ func (i *Input) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var config input.Input
 
 	switch t := wrapper.Type; t {
+	case "Bearer":
+		config = new(inputBearer.Config)
 	case "KubernetesTokenReview":
 		config = new(inputKubernetesTokenReview.Config)
 	default:

--- a/internal/input/bearer/input.go
+++ b/internal/input/bearer/input.go
@@ -1,0 +1,43 @@
+package bearer
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/robbiemcmichael/auth-mux/internal/token"
+	"github.com/robbiemcmichael/auth-mux/internal/types"
+)
+
+type Config struct {
+	Validator token.Config `yaml:"validator"`
+}
+
+func (c *Config) Handler(r *http.Request) (types.Validation, error) {
+	header := r.Header.Get("authorization")
+
+	if header == "" {
+		invalid := types.Validation{
+			Valid: false,
+			Error: "Missing authorization header",
+		}
+		return invalid, nil
+	}
+
+	auth := strings.SplitN(header, " ", 2)
+
+	if len(auth) != 2 || strings.ToLower(auth[0]) != "bearer" {
+		invalid := types.Validation{
+			Valid: false,
+			Error: "Expected bearer token in authorization header",
+		}
+		return invalid, nil
+	}
+
+	validation, err := c.Validator.Config.Validate(auth[1])
+	if err != nil {
+		return types.Validation{}, fmt.Errorf("validate token: %v", err)
+	}
+
+	return validation, nil
+}


### PR DESCRIPTION
Adds the `Bearer` input to support authentication via a bearer token. Uses the same `token` package as the `KubernetesTokenReview` input so that new token formats can be added and supported in both inputs without code duplication.